### PR TITLE
Only reset message when motion limit is reached

### DIFF
--- a/plugin/mediummode.vim
+++ b/plugin/mediummode.vim
@@ -46,8 +46,10 @@ endfunction
 
 " Reset the motion count
 function! s:MediumModeResetCount()
+  if s:motion_count == g:mediummode_allowed_motions
+    echo ''
+  endif
   let s:motion_count = 0
-  echo ''
 endfunction
 
 " Enable/disable functions


### PR DESCRIPTION
This prevents the annoying "Press ENTER or type command to continue"
message when entering a buffer.
