### PR TITLE
Reset after jump documentation fix

### DIFF
--- a/doc/mediummode.txt
+++ b/doc/mediummode.txt
@@ -52,7 +52,7 @@ Medium mode provides the following configuration variables:
 
 -------------------------------------------------------------------------------
 >
-  g:mediummode_allowed_character_motions
+  g:mediummode_allowed_motions
 <
   Set the number of consecutive character motions that are allowed before
   medium mode steps in

--- a/plugin/mediummode.vim
+++ b/plugin/mediummode.vim
@@ -39,15 +39,28 @@ function! s:MediumModeMotion(motion)
     let s:motion_count += 1
     return a:motion
   else
-    echo g:mediummode_disallowed_message
-    return ''
+    if !exists('s:mm_curchar')
+      let s:mm_curchar = {'line': line('.'), 'col': col('.')}
+      echo g:mediummode_disallowed_message
+      return ''
+    " Check if you're still at the same position
+    elseif s:mm_curchar.line == line('.') && s:mm_curchar.col == col('.')
+      echo g:mediummode_disallowed_message
+      return ''
+    else
+      " if not then allow the command and reset the count
+      call s:MediumModeResetCount()
+      return a:motion
+    endif
   endif
 endfunction
 
 " Reset the motion count
 function! s:MediumModeResetCount()
   let s:motion_count = 0
-  echo ''
+  if exists('s:mm_curchar')
+      unlet s:mm_curchar
+  endif
 endfunction
 
 " Enable/disable functions
@@ -99,4 +112,3 @@ command! -nargs=0 MediumModeToggle call s:MediumModeToggle()
 if g:mediummode_enabled
   call s:MediumModeEnable(1)
 endif
-


### PR DESCRIPTION
In my branch I made 3 changes:
- Fixed a variable name in the documentation to reflect the actual variable name (g:mediummode_allowed_motions vs. g:mediummode_allowed_character_motions)
- Changed the plugin to allow a reset of the character count after a jump command by comparing the column and line-number where the jump was triggered with the current line and column number (if it's changed, then reset the character count [e.g., assume a jump])
- Get rid of the `echo ''` in the s:MediumModeResetCount function that was causing me to have to hit enter to open up a new buffer in the current session

This is one of my first stabs at any Vimscript so if you find something to be non-performant or flat-out stupid I definitely won't be offended.

Awesome plugin by the way :)
